### PR TITLE
Added the x,y streaming functions

### DIFF
--- a/stream.hpp.in
+++ b/stream.hpp.in
@@ -2,6 +2,7 @@
 #define UTILITY_STREAM_H
 
 #include <istream>
+#include <map>
 
 #include "utility.hpp"
 
@@ -227,7 +228,75 @@ readString( std::istream& is,
             const std::string::size_type count,
             const char delim );
 
+  /** @{
+   *  @name Linked x,y template streaming functions
+   */
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  // Linked x,y template streaming functions
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  /** @brief Read a value from a stream
+   *
+   *  The readValue function will read a value of type Y from a stream and
+   *  transform it into its corresponding X value. Only those x values that are
+   *  referenced in the map are considered as legal x values.
+   *
+   *  Simply put, the readValue function will read a value of type Y from a
+   *  stream and transform it into its corresponding X value. This function can
+   *  for instance be used in the implementation of iostream operators of
+   *  enumerators for which the values are linked to other types such as
+   *  strings, integers or even doubles. This function is defined as a template
+   *  function so that the same code does not have to be written multiple
+   *  times.
+   *
+   *  @todo investigate the use of a template linker class instead of the map
+   *        to extend the x,y linking beyond one on one values (e.g. linked a
+   *        range of y values to a given x value, etc.).
+   *
+   *  @param[in,out] in   the input stream from which to read
+   *  @param[in,out] x    the x value
+   *  @param[in] values   the map linking y to x values
+   *
+   *  @return The input stream. If the function failed to read one of the values
+   *          from the map, the position in the stream will be unchanged and
+   *          std::ios_base::failbit will be set. In this case the value of x
+   *          will also be unchanged.
+   */
+  template <typename X, typename Y> std::istream& readValue(std::istream& in,
+          X& x, const std::map<Y, X>& values) noexcept;
+
+  /** @brief Write a value to a stream
+   *
+   *  The writeValue function writes the corresponding Y value to a stream
+   *  instead of the given X value. Only those x values that are referenced in
+   *  the map are considered as legal x values. Nothing will be written to the
+   *  stream if the x value is not referenced in the map.
+   *
+   *  Simply put, the writeValue function does the same thing by writing the
+   *  corresponding Y value of a given X value to a stream. This function can
+   *  for instance be used in the implementation of iostream operators of
+   *  enumerators for which the values are linked to other types such as
+   *  strings, integers or even doubles. This function is defined as a template
+   *  function so that the same code does not have to be written multiple
+   *  times.
+   *
+   *  @param[in,out] out   the output stream to which has to be written
+   *  @param[in] x         the x value
+   *  @param[in] values    the map linking x to y values
+   *
+   *  @return The modified output stream
+   */
+  template <typename X, typename Y> std::ostream& writeValue(std::ostream& out,
+          const X& x, const std::map<X, Y>& values) noexcept;
+  /** @}
+   */
 } // namespace stream
 } // namespace utility
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Template function implementation include files
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+#include "utility/stream/src/xystream.hpp"
 
 #endif

--- a/stream/CMakeLists.txt
+++ b/stream/CMakeLists.txt
@@ -2,6 +2,29 @@ if(${verbose_traversal})
   message(STATUS "Entered stream subdirectory")
 endif(${verbose_traversal})
 
+if(NOT(EXISTS "${utility_HEADER_DIR}/stream/src"))
+  file(MAKE_DIRECTORY "${utility_HEADER_DIR}/stream/src")
+endif(NOT(EXISTS "${utility_HEADER_DIR}/stream/src"))
+
+set(headers "")
+list(APPEND headers
+  "src/xystream"
+  )
+
+foreach(header ${headers})
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${header}.hpp.in"
+    "${utility_HEADER_DIR}/stream/${header}.hpp"
+    COPYONLY
+    )
+  list(APPEND utility_src_headers
+    "${CMAKE_CURRENT_SOURCE_DIR}/stream/${header}.hpp.in"
+    )
+  list(APPEND utility_bin_headers
+    "${utility_HEADER_DIR}/stream/${header}.hpp"
+    )
+endforeach(header)
+
 list(APPEND utility_src 
   "${CMAKE_CURRENT_SOURCE_DIR}/src/getBool.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/getLine.cpp"

--- a/stream/src/xystream.hpp.in
+++ b/stream/src/xystream.hpp.in
@@ -1,0 +1,115 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#ifndef UTILITY_STREAM_XYSTREAM_HPP
+#define UTILITY_STREAM_XYSTREAM_HPP
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+// system includes
+#include <iostream>
+#include <map>
+#include <stdexcept>
+
+// other includes
+
+namespace utility {
+
+  namespace stream {
+
+    /** @{
+     *  @name Linked x,y template streaming functions
+     */
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    // Linked x,y template streaming functions
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    /** @brief Read a value from a stream
+     *
+     *  The readValue function will read a value of type Y from a stream and
+     *  transform it into its corresponding X value. Only those x values that
+     *  are referenced in the map are considered as legal x values.
+     *
+     *  Simply put, the readValue function will read a value of type Y from a
+     *  stream and transform it into its corresponding X value. This function
+     *  can for instance be used in the implementation of iostream operators of
+     *  enumerators for which the values are linked to other types such as
+     *  strings, integers or even doubles. This function is defined as a
+     *  template function so that the same code does not have to be written
+     *  multiple times.
+     *
+     *  @todo investigate the use of a template linker class instead of the map
+     *        to extend the x,y linking beyond one on one values (e.g. linked a
+     *        range of y values to a given x value, etc.).
+     *
+     *  @param[in,out] in   the input stream from which to read
+     *  @param[in,out] x    the x value
+     *  @param[in] values   the map linking y to x values
+     *
+     *  @return The input stream. If the function failed to read one of the
+     *          values from the map, the position in the stream will be
+     *          unchanged and std::ios_base::failbit will be set. In this case
+     *          the value of x will also be unchanged.
+     */
+    template <typename X, typename Y> std::istream& readValue(std::istream& in,
+            X& x, const std::map<Y, X>& values) noexcept {
+
+      std::ios::pos_type pos = in.tellg();
+      Y y;
+      in >> y;
+
+      try {
+
+        x = values.at(y);
+      }
+      catch (std::out_of_range& error) {
+
+        in.clear();
+        in.seekg(pos);
+        in.clear(std::ios_base::failbit);
+      }
+
+      return in;
+    }
+
+    /** @brief Write a value to a stream
+     *
+     *  The writeValue function writes the corresponding Y value to a stream
+     *  instead of the given X value. Only those x values that are referenced in
+     *  the map are considered as legal x values. Nothing will be written to the
+     *  stream if the x value is not referenced in the map.
+     *
+     *  Simply put, the writeValue function does the same thing by writing the
+     *  corresponding Y value of a given X value to a stream. This function can
+     *  for instance be used in the implementation of iostream operators of
+     *  enumerators for which the values are linked to other types such as
+     *  strings, integers or even doubles. This function is defined as a template
+     *  function so that the same code does not have to be written multiple
+     *  times.
+     *
+     *  @param[in,out] out   the output stream to which has to be written
+     *  @param[in] x         the x value
+     *  @param[in] values    the map linking x to y values
+     *
+     *  @return The modified output stream
+     */
+    template <typename X, typename Y> std::ostream& writeValue(std::ostream& out,
+            const X& x, const std::map<X, Y>& values) noexcept {
+
+      try {
+
+        out << values.at(x);
+      }
+      catch (std::out_of_range& error) {
+
+        // do nothing
+      }
+
+      return out;
+    }
+    /** @}
+     */
+  } // stream namespace
+} // utility namespace
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#endif
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+

--- a/stream/test/xystream.test.cpp
+++ b/stream/test/xystream.test.cpp
@@ -1,0 +1,101 @@
+// other includes
+#include "catch.hpp"
+
+// what we're testing
+#include "utility/stream.hpp"
+
+extern int testNumber;
+
+// enum class to test the various functions
+enum class TestEnum {
+
+  VALUE1,
+  VALUE2
+};
+
+// maps used for testing
+const std::map<std::string,TestEnum> ENUMMAP
+  = { { "value1", TestEnum::VALUE1 } ,
+      { "value2", TestEnum::VALUE2 } };
+const std::map<TestEnum,std::string> STRINGMAP
+  = { { TestEnum::VALUE1, "value1" } ,
+      { TestEnum::VALUE2, "value2" } };
+const std::map<TestEnum,std::string> STRINGMAPEXCEPTION
+  = { { TestEnum::VALUE1, "value1" } };
+
+// ostream operator for the test enumerator (nice test output)
+std::ostream& operator<<(std::ostream& out, const TestEnum& value) {
+
+  return utility::stream::writeValue(out, value, STRINGMAP);
+}
+
+SCENARIO("Test readValue ", "[utility/stream], [X,Y stream]") {
+
+  GIVEN("an input stream, an enum class and associated strings"){
+
+    std::istringstream in("value1 value2 this should fail");
+    WHEN("reading values from the stream") {
+
+      TestEnum value1, value2;
+      std::string string;
+
+      utility::stream::readValue(in, value1, ENUMMAP);
+      utility::stream::readValue(in, value2, ENUMMAP);
+      THEN("the enum values are found") {
+
+        LOG(INFO) << "Test " << ++testNumber
+                  << ": [readValue] No Errors Expected";
+        REQUIRE( TestEnum::VALUE1 == value1 );
+        REQUIRE( TestEnum::VALUE2 == value2 );
+      }
+
+      utility::stream::readValue(in, value1, ENUMMAP);
+      THEN("the stream goes into fail and the value is unchanged") {
+
+        LOG(INFO) << "Test " << ++testNumber
+                  << ": [readValue] No Errors Expected";
+        REQUIRE( TestEnum::VALUE1 == value1 );
+        REQUIRE( true == in.fail() );
+      }
+
+      in.clear();
+      std::getline(in, string);
+      THEN("the remaining stream should be \" this should fail\"") {
+
+        LOG(INFO) << "Test " << ++testNumber
+                  << ": [readValue] No Errors Expected";
+        REQUIRE( " this should fail" == string );
+      }
+    }
+  }
+}
+
+SCENARIO("Test writeValue ", "[utility/stream], [X,Y stream]") {
+
+  GIVEN("an output stream, an enum class and associated strings"){
+
+    std::ostringstream out;
+    WHEN("writing values from the stream") {
+
+      utility::stream::writeValue(out, TestEnum::VALUE1, STRINGMAP);
+      out << " ";
+      utility::stream::writeValue(out, TestEnum::VALUE2, STRINGMAP);
+      THEN("the enum values are written to the stream") {
+
+        LOG(INFO) << "Test " << ++testNumber
+                  << ": [readValue] No Errors Expected";
+        REQUIRE( out.str() == "value1 value2" );
+      }
+
+      out << " not modified";
+      utility::stream::writeValue(out, TestEnum::VALUE2, STRINGMAPEXCEPTION);
+      THEN("the stream goes into fail and the value is unchanged") {
+
+        LOG(INFO) << "Test " << ++testNumber
+                  << ": [readValue] No Errors Expected";
+        REQUIRE( out.str() == "value1 value2 not modified" );
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
I have added these streaming functions to simplify the implementation of enumerator to string and vice versa.

I have already a working version of the unit library up and running with length and area units. I pushed this first because I need these additional functions. Once the merge is complete, I will push the unit library for you to have a look at.
